### PR TITLE
update 支持webstorm下的断点调试

### DIFF
--- a/lib/app_worker.js
+++ b/lib/app_worker.js
@@ -4,41 +4,47 @@ const fs = require('fs');
 const debug = require('debug')('egg-cluster');
 const consoleLogger = require('./utils/console');
 
-// $ node app_worker.js options
-const options = JSON.parse(process.argv[2]);
+function setup( opt ){
+    // $ node app_worker.js options
+    const options = opt;
 
-const Application = require(options.customEgg).Application;
-debug('new Application with options %j', options);
-const app = new Application(options);
-app.ready(startServer);
+    const Application = require(options.customEgg).Application;
+    debug('new Application with options %j', options);
+    const app = new Application(options);
+    app.ready(startServer);
 
-// exit if worker start timeout
-app.once('startTimeout', startTimeoutHanlder);
-function startTimeoutHanlder() {
-  consoleLogger.error('[app_worker] App Worker start timeout, exiting now!');
-  process.exit(1);
+    // exit if worker start timeout
+    app.once('startTimeout', startTimeoutHanlder);
+    function startTimeoutHanlder() {
+        consoleLogger.error('[app_worker] App Worker start timeout, exiting now!');
+        process.exit(1);
+    }
+
+    function startServer() {
+        app.removeListener('startTimeout', startTimeoutHanlder);
+        let server;
+        if (options.https) {
+            server = require('https').createServer({
+                key: fs.readFileSync(options.key),
+                cert: fs.readFileSync(options.cert),
+            }, app.callback());
+        } else {
+            server = require('http').createServer(app.callback());
+        }
+
+        // emit `server` event in app
+        app.emit('server', server);
+
+        server.listen(options.port);
+    }
+
+    // exit gracefully
+    process.once('SIGTERM', () => {
+        consoleLogger.warn('[app_worker] App Worker exit with signal SIGTERM');
+        process.exit(0);
+    });
 }
 
-function startServer() {
-  app.removeListener('startTimeout', startTimeoutHanlder);
-  let server;
-  if (options.https) {
-    server = require('https').createServer({
-      key: fs.readFileSync(options.key),
-      cert: fs.readFileSync(options.cert),
-    }, app.callback());
-  } else {
-    server = require('http').createServer(app.callback());
-  }
+process.argv[ 2 ] && setup( JSON.parse( process.argv[ 2 ] ) );
 
-  // emit `server` event in app
-  app.emit('server', server);
-
-  server.listen(options.port);
-}
-
-// exit gracefully
-process.once('SIGTERM', () => {
-  consoleLogger.warn('[app_worker] App Worker exit with signal SIGTERM');
-  process.exit(0);
-});
+module.exports.setup    = setup;

--- a/lib/master.js
+++ b/lib/master.js
@@ -87,7 +87,13 @@ class Master extends EventEmitter {
         return;
       }
       this.options.clusterPort = port;
-      this.forkAgentWorker();
+      if( !this.isDebug ){
+        this.forkAgentWorker();
+      } else {
+        let _appWorker  = require( appWorkerFile );
+        _appWorker.setup( this.options );
+        this.logger.info('[master] app Worker setup success');
+      }
     });
   }
 


### PR DESCRIPTION
封装了app_worker 下的启动执行，允许export调用执行
变更master.js中fork worker处 根据this.isDebug参数 直接启动app


目的：当前启动状态下，程序为master-worker方式，webstorm下开发调试不友好，希望可以在开发时采用debug模式，进行断点调试