### PR TITLE
feat: set harmony depending on node version

### DIFF
--- a/lib/utils/options.js
+++ b/lib/utils/options.js
@@ -17,6 +17,9 @@ module.exports = function(options) {
     https: false,
     key: '',
     cert: '',
+    opt: {
+      execArgv: process.execArgv,
+    },
   };
   options = extend(defaults, options);
   if (!options.workers) {
@@ -50,6 +53,17 @@ module.exports = function(options) {
     process.env.NO_DEPRECATION = '*';
   }
 
+  // node 6 fail with `Generator is already running` when harmony v8 option on
+  const idx = options.opt.execArgv.indexOf('--harmony');
+  if (Number(process.versions.modules) < 48) {
+    if (idx === -1) {
+      options.opt.execArgv.push('--harmony');
+    }
+  } else {
+    if (idx >= 0) {
+      options.opt.execArgv.splice(idx, 1);
+    }
+  }
   return options;
 };
 

--- a/test/fixtures/apps/app-die/app/router.js
+++ b/test/fixtures/apps/app-die/app/router.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function(app) {
-  app.get('/exit', function*() {
+  app.get('/exit', function* () {
     process.exit(1);
   });
 };

--- a/test/fixtures/apps/app-harmony/agent.js
+++ b/test/fixtures/apps/app-harmony/agent.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = () => {
+  console.log(process.execArgv.includes('--harmony') ? 'agent with harmony' : 'agent without harmony');
+};

--- a/test/fixtures/apps/app-harmony/app.js
+++ b/test/fixtures/apps/app-harmony/app.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = () => {
+  console.log(process.execArgv.includes('--harmony') ? 'app with harmony' : 'app without harmony');
+};

--- a/test/fixtures/apps/app-harmony/package.json
+++ b/test/fixtures/apps/app-harmony/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "app-harmony"
+}

--- a/test/fixtures/apps/app-kill/app/router.js
+++ b/test/fixtures/apps/app-kill/app/router.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function(app) {
-  app.get('/kill', function*() {
+  app.get('/kill', function* () {
     const signal = this.query.signal && this.query.signal.toUpperCase();
     this.logger.info('kill by signal', signal, process.execArgv);
     process.kill(process.pid, signal);

--- a/test/fixtures/apps/frameworkapp/app/controller/home.js
+++ b/test/fixtures/apps/frameworkapp/app/controller/home.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function*() {
+module.exports = function* () {
   this.body = {
     frameworkCore: !!this.app.framework,
     frameworkPlugin: !!this.app.custom,

--- a/test/fixtures/apps/pid/app/router.js
+++ b/test/fixtures/apps/pid/app/router.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function(app) {
-  app.get('/exit', function*() {
+  app.get('/exit', function* () {
     process.exit(1);
   });
 };

--- a/test/master.test.js
+++ b/test/master.test.js
@@ -20,10 +20,10 @@ describe('test/lib/cluster/master.test.js', () => {
       app = utils.cluster('apps/master-worker-started');
 
       app.expect('stdout', /egg start/)
-      .expect('stdout', /egg started/)
-      .expect('stdout', /\\"clusterPort\\":\d+/)
-      .expect('code', 0)
-      .end(done);
+        .expect('stdout', /egg started/)
+        .expect('stdout', /\\"clusterPort\\":\d+/)
+        .expect('code', 0)
+        .end(done);
     });
 
     it('start success in prod env', done => {
@@ -31,14 +31,14 @@ describe('test/lib/cluster/master.test.js', () => {
       app = utils.cluster('apps/mock-production-app').debug(false);
 
       app.expect('stdout', /egg start/)
-      .expect('stdout', /egg started/)
-      .expect('code', 0)
-      .end(err => {
-        assert.ifError(err);
-        console.log(app.stdout);
-        console.log(app.stderr);
-        done();
-      });
+        .expect('stdout', /egg started/)
+        .expect('code', 0)
+        .end(err => {
+          assert.ifError(err);
+          console.log(app.stdout);
+          console.log(app.stderr);
+          done();
+        });
     });
   });
 
@@ -50,9 +50,9 @@ describe('test/lib/cluster/master.test.js', () => {
       app = utils.cluster('apps/master-worker-started');
 
       yield app.expect('stdout', /egg start/)
-      .expect('stdout', /egg started/)
-      .expect('code', 0)
-      .end();
+        .expect('stdout', /egg started/)
+        .expect('code', 0)
+        .end();
 
       app.proc.kill();
 
@@ -67,9 +67,9 @@ describe('test/lib/cluster/master.test.js', () => {
       app = utils.cluster('apps/master-worker-started');
 
       yield app.expect('stdout', /egg start/)
-      .expect('stdout', /egg started/)
-      .expect('code', 0)
-      .end();
+        .expect('stdout', /egg started/)
+        .expect('code', 0)
+        .end();
 
       app.proc.kill('SIGTERM');
       yield sleep(1000);
@@ -83,9 +83,9 @@ describe('test/lib/cluster/master.test.js', () => {
       app = utils.cluster('apps/master-worker-started');
 
       yield app.expect('stdout', /egg start/)
-      .expect('stdout', /egg started/)
-      .expect('code', 0)
-      .end();
+        .expect('stdout', /egg started/)
+        .expect('code', 0)
+        .end();
 
       app.proc.kill('SIGQUIT');
       yield sleep(1000);
@@ -181,9 +181,9 @@ describe('test/lib/cluster/master.test.js', () => {
 
     it('should online cluster mode startup success', done => {
       request(app.callback())
-      .get('/portal/i.htm')
-      .expect('hi cluster')
-      .expect(200, done);
+        .get('/portal/i.htm')
+        .expect('hi cluster')
+        .expect(200, done);
     });
   });
 
@@ -201,13 +201,13 @@ describe('test/lib/cluster/master.test.js', () => {
 
     it('should start with prod env', done => {
       request(app.callback())
-      .get('/')
-      .expect({
-        frameworkCore: true,
-        frameworkPlugin: true,
-        frameworkAgent: true,
-      })
-      .expect(200, done);
+        .get('/')
+        .expect({
+          frameworkCore: true,
+          frameworkPlugin: true,
+          frameworkAgent: true,
+        })
+        .expect(200, done);
     });
   });
 
@@ -321,9 +321,9 @@ describe('test/lib/cluster/master.test.js', () => {
       app = utils.cluster('apps/agent-debug-port');
 
       app
-      .coverage(false)
-      .expect('stdout', /debug port of agent is 5856/)
-      .end(done);
+        .coverage(false)
+        .expect('stdout', /debug port of agent is 5856/)
+        .end(done);
     });
   });
 
@@ -336,9 +336,23 @@ describe('test/lib/cluster/master.test.js', () => {
 
     it('should online sticky cluster mode startup success', done => {
       request(app.callback())
-      .get('/portal/i.htm')
-      .expect('hi cluster')
-      .expect(200, done);
+        .get('/portal/i.htm')
+        .expect('hi cluster')
+        .expect(200, done);
+    });
+  });
+
+  describe('--harmony', () => {
+    it('should set --harmony depending on node version', () => {
+      const app = utils.cluster('apps/app-harmony');
+      const v = Number(process.versions.modules);
+      return app
+        .expect('stdout', v < 48 ? /app with harmony/ : /app without harmony/)
+        .expect('stdout', v < 48 ? /agent with harmony/ : /agent without harmony/)
+        .end()
+        .then(() => {
+          return app.close();
+        });
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
在 master 里根据 node 版本来设置 `--harmony`