### PR TITLE
chore:more easy debug use webstorm remote debug when use mm.cluster #878

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ run
 .tmp
 *.log
 .vscode
+.idea
+.DS_Store

--- a/lib/master.js
+++ b/lib/master.js
@@ -163,9 +163,12 @@ class Master extends EventEmitter {
 
     const args = [ JSON.stringify(this.options) ];
     debug('Start appWorker with args %j', args);
+    const execArgv = this.options.appWorkBrk === true && [ '--debug-brk' ] || undefined;
+    this.logger.info('[master] App Worker start with execArgv: %s', execArgv);
     cfork({
       exec: appWorkerFile,
       args,
+      execArgv,
       silent: false,
       count: this.options.workers,
       // don't refork in local env

--- a/test/app_worker.test.js
+++ b/test/app_worker.test.js
@@ -4,6 +4,7 @@ const mm = require('egg-mock');
 const request = require('supertest');
 const sleep = require('mz-modules/sleep');
 const utils = require('./utils');
+const format = require('util').format;
 
 describe('test/lib/cluster/app_worker.test.js', () => {
 
@@ -144,6 +145,27 @@ describe('test/lib/cluster/app_worker.test.js', () => {
         .expect('stderr', /nodejs.AppWorkerDiedError: \[master\]/)
         .expect('stderr', /App Worker#1:\d+ died/)
         .end(done);
+    });
+  });
+
+  describe('app worker with appWorkBrk', () => {
+    it('should append execArgv to the app work', function(done) {
+      const brkConfig = [ '--debug-brk' ];
+      app = utils.cluster('apps/app-debug-brk', {
+        opt: { execArgv: [ '--debug' ] },
+        appWorkBrk: true,
+      });
+      const expectString = format(
+        'App Worker start with execArgv: %s', brkConfig);
+      let called = false;
+      app.on('stdout_data', function(buf) {
+        const out = buf.toString();
+        if (out.indexOf(expectString) > -1 && !called) {
+          called = true;
+          done();
+        }
+        // https://github.com/Microsoft/vscode/issues/5831
+      });
     });
   });
 

--- a/test/fixtures/apps/app-debug-brk/app.js
+++ b/test/fixtures/apps/app-debug-brk/app.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = () => {
+  console.log('debug port of app is %s', process.debugPort);
+};

--- a/test/fixtures/apps/app-debug-brk/package.json
+++ b/test/fixtures/apps/app-debug-brk/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "agent-debug-port"
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->


- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

#878  
增加一个配置,可以用webstorm单独对app进程进行远程调试.
webstorm 只能attach 两层调试. 如mocha 执行的进程 和mm.cluster启动的master进程. master进程再起的app进程和agent 进程 attach不上.所以webstorm得调试基本用不了.

之前看官网上的说明,配置
"scripts": {
    "debug": "egg-bin dev $NODE_DEBUG_OPTION"
  }
然后通过webstorm的npm 来启动调试,一直也没有成功.应该也是这个原因.
egg-bin dev 内部起了一个进程,到master进程是第二层,app进程和agent进程是第三层, webstorm根本就attach不了app进程,agent进程,但是所有的进程都共享了$NODE_DEBUG_OPTION里面的--debug-brk,所以app进程和 agent进程一直挂在那里 所以其实egg根本启动不了.这跟观察结果也很像

但是用webstorm直接调试自动生成的index.js 是可以的. 因为这里master进程和app进程 agent进程只有两层
```javascript
require('egg').startCluster({
  baseDir: __dirname,
  workers: 1,
  port: process.env.PORT || 7001, // default to 7001
})
```
这个pull request 就是简单的增加一个配置appWorkBrk
```javavscript
 let options = {
    // baseDir: '../../',
    workers: 1,
 opt: {execArgv: ['--debug=9228']},
    // port,
    appWorkBrk: true,
    coverage: false,
    sticky: false,
  }
```
这样启动app进程时候加了一个--debug-brk .然后再用webstorm的远程调试 9228+1=9229端口就可以了.
理论上agent进程搞个单独配置出来应该也可以.

觉得现在要用webstorm调试mm.cluster,只能这样搞了.  不想换成vscode,vim插件不好用..

