### PR TITLE
fix: fix deperated api

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -184,7 +184,7 @@ class Master extends EventEmitter {
     });
     cluster.on('disconnect', worker => {
       this.logger.info('[master] App Worker#%s:%s disconnect, suicide: %s, state: %s, current workers: %j',
-        worker.id, worker.process.pid, worker.suicide, worker.state, Object.keys(cluster.workers));
+        worker.id, worker.process.pid, worker.exitedAfterDisconnect, worker.state, Object.keys(cluster.workers));
     });
     cluster.on('exit', (worker, code, signal) => {
       this.messenger.send({
@@ -274,7 +274,7 @@ class Master extends EventEmitter {
       const message = util.format(
         '[master] App Worker#%s:%s died (code: %s, signal: %s, suicide: %s, state: %s), current workers: %j',
         worker.id, worker.process.pid, worker.process.exitCode, signal,
-        worker.suicide, worker.state,
+        worker.exitedAfterDisconnect, worker.state,
         Object.keys(cluster.workers)
       );
       const err = new Error(message);


### PR DESCRIPTION
`worker.suicide` is deperated in node.js 6.0, use `worker.exitedAfterDisconnect` instead.  See https://nodejs.org/dist/latest-v6.x/docs/api/cluster.html#cluster_worker_suicide

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
worker.suicide deprecated since: v6.0.0, see [cluster_worker_suicide](https://nodejs.org/dist/latest-v6.x/docs/api/cluster.html#cluster_worker_suicide)
