### PR TITLE
feat: add worker manager and check worker/agent status

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -120,7 +120,6 @@ class Master extends EventEmitter {
         err.message = '[master] try get free port error, ' + err.message;
         this.logger.error(err);
         process.exit(1);
-        return;
       }
       this.options.clusterPort = port;
       this.forkAgentWorker();

--- a/lib/master.js
+++ b/lib/master.js
@@ -12,6 +12,7 @@ const detectPort = require('detect-port');
 const ConsoleLogger = require('egg-logger').EggConsoleLogger;
 const utility = require('utility');
 
+const Manager = require('./utils/manager');
 const parseOptions = require('./utils/options');
 const Messenger = require('./utils/messenger');
 
@@ -37,13 +38,13 @@ class Master extends EventEmitter {
   constructor(options) {
     super();
     this.options = parseOptions(options);
+    this.workerManager = new Manager();
     this.messenger = new Messenger(this);
 
     ready.mixin(this);
 
     this.isProduction = isProduction();
     this.agentWorkerIndex = 0;
-    this.agentWorker = null;
     this.closed = false;
     this[REALPORT] = this.options.port;
 
@@ -54,10 +55,6 @@ class Master extends EventEmitter {
     if (process.env.EGG_SERVER_ENV === 'local' || process.env.NODE_ENV === 'development') {
       this.logMethod = 'debug';
     }
-
-    this.log = function log(...args) {
-      this.logger[this.logMethod](...args);
-    };
 
     // get the real framework info
     const frameworkPath = this.options.framework;
@@ -86,6 +83,9 @@ class Master extends EventEmitter {
       this.messenger.send({ action, to: 'parent', data: { port: this[REALPORT], address: this[APP_ADDRESS] } });
       this.messenger.send({ action, to: 'app', data: this.options });
       this.messenger.send({ action, to: 'agent', data: this.options });
+
+      // start check agent and worker status
+      this.workerManager.startCheck();
     });
 
     this.on('agent-exit', this.onAgentExit.bind(this));
@@ -126,6 +126,23 @@ class Master extends EventEmitter {
       this.forkAgentWorker();
     });
 
+    // exit when agent or worker exception
+    this.workerManager.on('exception', ({ agent, worker }) => {
+      const err = new Error(`[master] ${agent} agent and ${worker} worker(s) alive, exit to avoid unknown state`);
+      err.name = 'ClusterWorkerExceptionError';
+      err.status = { agent, worker };
+      this.logger.error(err);
+      process.exit(1);
+      return;
+    });
+  }
+
+  log(...args) {
+    this.logger[this.logMethod](...args);
+  }
+
+  get agentWorker() {
+    return this.workerManager.agent;
   }
 
   startMasterSocketServer(cb) {
@@ -147,7 +164,7 @@ class Master extends EventEmitter {
 
   stickyWorker(ip) {
     const workerNumbers = this.options.workers;
-    const ws = Array.from(this.workers.keys());
+    const ws = this.workerManager.listWorkerIds();
 
     let s = '';
     for (let i = 0; i < ip.length; i++) {
@@ -157,7 +174,7 @@ class Master extends EventEmitter {
     }
     s = Number(s);
     const pid = ws[s % workerNumbers];
-    return this.workers.get(pid);
+    return this.workerManager.getWorker(pid);
   }
 
   forkAgentWorker() {
@@ -170,7 +187,8 @@ class Master extends EventEmitter {
     const debugPort = 5800;
     if (this.options.isDebug) opt.execArgv = process.execArgv.concat([ `--debug-port=${debugPort}` ]);
 
-    const agentWorker = this.agentWorker = childprocess.fork(agentWorkerFile, args, opt);
+    const agentWorker = childprocess.fork(agentWorkerFile, args, opt);
+    this.workerManager.setAgent(agentWorker);
     agentWorker.id = ++this.agentWorkerIndex;
     this.log('[master] agent_worker#%s:%s start with clusterPort:%s',
       agentWorker.id, agentWorker.pid, this.options.clusterPort);
@@ -207,8 +225,6 @@ class Master extends EventEmitter {
     this.isAllAppWorkerStarted = false;
     this.startSuccessCount = 0;
 
-    this.workers = new Map();
-
     const args = [ JSON.stringify(this.options) ];
     this.log('[master] start appWorker with args %j', args);
     cfork({
@@ -223,7 +239,7 @@ class Master extends EventEmitter {
     let debugPort = process.debugPort;
     cluster.on('fork', worker => {
       worker.disableRefork = true;
-      this.workers.set(worker.process.pid, worker);
+      this.workerManager.setWorker(worker);
       worker.on('message', msg => {
         if (typeof msg === 'string') msg = { action: msg, data: msg };
         msg.from = 'app';
@@ -294,7 +310,7 @@ class Master extends EventEmitter {
 
     this.messenger.send({ action: 'egg-pids', to: 'app', data: [] });
     const agentWorker = this.agentWorker;
-    this.agentWorker = null;
+    this.workerManager.deleteAgent(this.agentWorker);
 
     const err = new Error(util.format('[master] agent_worker#%s:%s died (code: %s, signal: %s)',
       agentWorker.id, agentWorker.pid, data.code, data.signal));
@@ -330,7 +346,7 @@ class Master extends EventEmitter {
     this.messenger.send({ action: 'egg-pids', to: 'app', data: [ this.agentWorker.pid ] });
     // should send current worker pids when agent restart
     if (this.isStarted) {
-      this.messenger.send({ action: 'egg-pids', to: 'agent', data: getListeningWorker(this.workers) });
+      this.messenger.send({ action: 'egg-pids', to: 'agent', data: this.workerManager.getListeningWorker() });
     }
 
     this.messenger.send({ action: 'agent-start', to: 'app' });
@@ -348,7 +364,7 @@ class Master extends EventEmitter {
   onAppExit(data) {
     if (this.closed) return;
 
-    const worker = this.workers.get(data.workerPid);
+    const worker = this.workerManager.getWorker(data.workerPid);
 
     if (!worker.isDevReload) {
       const signal = data.signal;
@@ -372,9 +388,9 @@ class Master extends EventEmitter {
 
     // remove all listeners to avoid memory leak
     worker.removeAllListeners();
-    this.workers.delete(data.workerPid);
+    this.workerManager.deleteWorker(data.workerPid);
     // send message to agent with alive workers
-    this.messenger.send({ action: 'egg-pids', to: 'agent', data: getListeningWorker(this.workers) });
+    this.messenger.send({ action: 'egg-pids', to: 'agent', data: this.workerManager.getListeningWorker() });
 
     if (this.isAllAppWorkerStarted) {
       // cfork will only refork at production mode
@@ -398,7 +414,7 @@ class Master extends EventEmitter {
    *  - {Object} address - server address
    */
   onAppStart(data) {
-    const worker = this.workers.get(data.workerPid);
+    const worker = this.workerManager.getWorker(data.workerPid);
     const address = data.address;
 
     // ignore unspecified port
@@ -413,7 +429,7 @@ class Master extends EventEmitter {
     this.messenger.send({
       action: 'egg-pids',
       to: 'agent',
-      data: getListeningWorker(this.workers),
+      data: this.workerManager.getListeningWorker(),
     });
 
     this.startSuccessCount++;
@@ -505,16 +521,6 @@ class Master extends EventEmitter {
 }
 
 module.exports = Master;
-
-function getListeningWorker(workers) {
-  const keys = [];
-  for (const id of workers.keys()) {
-    if (workers.get(id).state === 'listening') {
-      keys.push(id);
-    }
-  }
-  return keys;
-}
 
 function isProduction() {
   const serverEnv = process.env.EGG_SERVER_ENV;

--- a/lib/master.js
+++ b/lib/master.js
@@ -129,10 +129,9 @@ class Master extends EventEmitter {
     this.workerManager.on('exception', ({ agent, worker }) => {
       const err = new Error(`[master] ${agent} agent and ${worker} worker(s) alive, exit to avoid unknown state`);
       err.name = 'ClusterWorkerExceptionError';
-      err.status = { agent, worker };
+      err.count = { agent, worker };
       this.logger.error(err);
       process.exit(1);
-      return;
     });
   }
 
@@ -345,7 +344,7 @@ class Master extends EventEmitter {
     this.messenger.send({ action: 'egg-pids', to: 'app', data: [ this.agentWorker.pid ] });
     // should send current worker pids when agent restart
     if (this.isStarted) {
-      this.messenger.send({ action: 'egg-pids', to: 'agent', data: this.workerManager.getListeningWorker() });
+      this.messenger.send({ action: 'egg-pids', to: 'agent', data: this.workerManager.getListeningWorkerIds() });
     }
 
     this.messenger.send({ action: 'agent-start', to: 'app' });
@@ -389,7 +388,7 @@ class Master extends EventEmitter {
     worker.removeAllListeners();
     this.workerManager.deleteWorker(data.workerPid);
     // send message to agent with alive workers
-    this.messenger.send({ action: 'egg-pids', to: 'agent', data: this.workerManager.getListeningWorker() });
+    this.messenger.send({ action: 'egg-pids', to: 'agent', data: this.workerManager.getListeningWorkerIds() });
 
     if (this.isAllAppWorkerStarted) {
       // cfork will only refork at production mode
@@ -428,7 +427,7 @@ class Master extends EventEmitter {
     this.messenger.send({
       action: 'egg-pids',
       to: 'agent',
-      data: this.workerManager.getListeningWorker(),
+      data: this.workerManager.getListeningWorkerIds(),
     });
 
     this.startSuccessCount++;

--- a/lib/utils/manager.js
+++ b/lib/utils/manager.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const EventEmitter = require('events');
+
+// worker manager to record agent and worker forked by egg-cluster
+// can do some check stuff here to monitor the healthy
+class Manager extends EventEmitter {
+  constructor() {
+    super();
+    this.workers = new Map();
+    this.agent = null;
+  }
+
+  setAgent(agent) {
+    this.agent = agent;
+  }
+
+  deleteAgent() {
+    this.agent = null;
+  }
+
+  setWorker(worker) {
+    this.workers.set(worker.process.pid, worker);
+  }
+
+  getWorker(pid) {
+    return this.workers.get(pid);
+  }
+
+  deleteWorker(pid) {
+    this.workers.delete(pid);
+  }
+
+  listWorkerIds() {
+    return Array.from(this.workers.keys());
+  }
+
+  getListeningWorker() {
+    const keys = [];
+    for (const id of this.workers.keys()) {
+      if (this.getWorker(id).state === 'listening') {
+        keys.push(id);
+      }
+    }
+    return keys;
+  }
+
+  status() {
+    return {
+      agent: this.agent ? 1 : 0,
+      worker: this.listWorkerIds().length,
+    };
+  }
+
+  // check agent and worker must both alive
+  // if exception appear 3 times, emit an exception event
+  startCheck() {
+    this.exception = 0;
+    this.timer = setInterval(() => {
+      const status = this.status();
+      if (status.agent && status.worker) {
+        this.exception = 0;
+        return;
+      }
+      this.exception++;
+      if (this.exception >= 3) {
+        this.emit('exception', status);
+        clearInterval(this.timer);
+      }
+    }, 10000);
+  }
+}
+
+module.exports = Manager;

--- a/lib/utils/manager.js
+++ b/lib/utils/manager.js
@@ -35,7 +35,7 @@ class Manager extends EventEmitter {
     return Array.from(this.workers.keys());
   }
 
-  getListeningWorker() {
+  getListeningWorkerIds() {
     const keys = [];
     for (const id of this.workers.keys()) {
       if (this.getWorker(id).state === 'listening') {
@@ -45,7 +45,7 @@ class Manager extends EventEmitter {
     return keys;
   }
 
-  status() {
+  count() {
     return {
       agent: this.agent ? 1 : 0,
       worker: this.listWorkerIds().length,
@@ -57,14 +57,14 @@ class Manager extends EventEmitter {
   startCheck() {
     this.exception = 0;
     this.timer = setInterval(() => {
-      const status = this.status();
-      if (status.agent && status.worker) {
+      const count = this.count();
+      if (count.agent && count.worker) {
         this.exception = 0;
         return;
       }
       this.exception++;
       if (this.exception >= 3) {
-        this.emit('exception', status);
+        this.emit('exception', count);
         clearInterval(this.timer);
       }
     }, 10000);

--- a/test/fixtures/apps/agent-exit/agent.js
+++ b/test/fixtures/apps/agent-exit/agent.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = agent => {
+  agent.messenger.on('egg-ready', () => {
+    process.exit(1);
+  });
+};

--- a/test/fixtures/apps/agent-exit/package.json
+++ b/test/fixtures/apps/agent-exit/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "agent-start-error"
+}

--- a/test/fixtures/apps/app-exit/app.js
+++ b/test/fixtures/apps/app-exit/app.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = app => {
+  app.messenger.on('egg-ready', () => {
+    process.exit(1);
+  });
+};

--- a/test/fixtures/apps/app-exit/package.json
+++ b/test/fixtures/apps/app-exit/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "agent-start-error"
+}

--- a/test/master.test.js
+++ b/test/master.test.js
@@ -627,4 +627,28 @@ describe('test/master.test.js', () => {
         .expect(200);
     });
   });
+
+  describe('agent and worker exception', () => {
+    it('should exit when no agent after check 3 times', done => {
+      app = utils.cluster('apps/agent-exit');
+      setTimeout(() => {
+        app.proc.once('exit', () => {
+          assert(app.stderr.includes('nodejs.ClusterWorkerExceptionError: [master] 0 agent and 1 worker(s) alive, exit to avoid unknown state'));
+          assert(app.stderr.includes('[master] exit with code:1'));
+          done();
+        });
+      }, 1000);
+    });
+
+    it('should exit when no app after check 3 times', done => {
+      app = utils.cluster('apps/app-exit');
+      setTimeout(() => {
+        app.proc.once('exit', () => {
+          assert(app.stderr.includes('nodejs.ClusterWorkerExceptionError: [master] 1 agent and 0 worker(s) alive, exit to avoid unknown state'));
+          assert(app.stderr.includes('[master] exit with code:1'));
+          done();
+        });
+      }, 1000);
+    });
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

Add WorkerManager to manage all workers and agent, add a checker to ensure worker and agent both alive. In some extreme situation(such like no disk space), workers all died but agent and master still alive, this leads the egg application in an unknown state.