### PR TITLE
feat: add 400 response for broken client request to instead of empty response

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.js]
+indent_size = 2

--- a/lib/app_worker.js
+++ b/lib/app_worker.js
@@ -51,6 +51,22 @@ function startServer(err) {
   // emit `server` event in app
   app.emit('server', server);
 
+  const DEFAULT_BAD_REQUEST_HTML = '<html>' +
+    '<head><title>400 Bad Request</title></head>' +
+    '<body bgcolor="white">' +
+    '<center><h1>400 Bad Request</h1></center>' +
+    '<hr><center>❤</center>' +
+    '</body>' +
+    '</html>';
+  const DEFAULT_BAD_REQUEST_HTML_LENGTH = Buffer.byteLength(DEFAULT_BAD_REQUEST_HTML);
+  const DEFAULT_BAD_REQUEST_RESPONSE =
+    `HTTP/1.1 400 Bad Request\r\nContent-Length: ${DEFAULT_BAD_REQUEST_HTML_LENGTH}\r\n\r\n${DEFAULT_BAD_REQUEST_HTML}`;
+
+  server.on('clientError', (err, sock) => {
+    consoleLogger.error('[app_worker] broken request: %s, code: %s', err.message, err.code);
+    sock.end(DEFAULT_BAD_REQUEST_RESPONSE);
+  });
+
   if (options.sticky) {
     server.listen(0, '127.0.0.1');
     // Listen to messages sent from the master. Ignore everything else.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
server

##### Description of change
<!-- Provide a description of the change below this comment. -->

Egg.js will do no response while client error. This PR makes server response a 400 Bad Request instead.

+ Refs: https://zhuanlan.zhihu.com/p/31966196
+ Refs: https://nodejs.org/dist/latest-v8.x/docs/api/http.html#http_event_clienterror