### PR TITLE
fix: remove useless unittest

### DIFF
--- a/test/ts.test.js
+++ b/test/ts.test.js
@@ -27,15 +27,4 @@ describe('test/ts.test.js', () => {
       .expect('code', 0)
       .end(done);
   });
-
-  it('require ts-node register', done => {
-    mm.env('local');
-    app = utils.cluster('apps/ts', {
-      typescript: true,
-    });
-    // app.debug();
-    app.expect('stderr', /`require.extensions` should contains `.ts`/)
-      .expect('code', 1)
-      .end(done);
-  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

这个单测是用于原来 egg-core 中在仅有 typescript 入参却没 require.extensions 的情况下抛异常，现在在 egg-core 中改成了抛 warnning，所以这个单测已经没必要了，可以移除一下。

releated https://github.com/eggjs/egg-cluster/pull/64#issuecomment-381299730
