### PR TITLE
fix: `cluster.listen.port` not work when 7001 is used

### DIFF
--- a/lib/app_worker.js
+++ b/lib/app_worker.js
@@ -13,7 +13,7 @@ debug('new Application with options %j', options);
 const app = new Application(options);
 const clusterConfig = app.config.cluster || /* istanbul ignore next */ {};
 const listenConfig = clusterConfig.listen || /* istanbul ignore next */ {};
-const port = options.port = options.port || listenConfig.port;
+const port = options.port = listenConfig.port || options.port;
 process.send({ to: 'master', action: 'realport', data: port });
 app.ready(startServer);
 


### PR DESCRIPTION
if I run an app not set `cluster.listen.port`, it will use `defautlPort: 7001`
the I run another app which set `cluster.listen.port`, **will not work!**
because egg-bin will **detect a new port**, that will take precedence


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
