### PR TITLE
fix: fix messenger#sendTo

### DIFF
--- a/lib/utils/messenger.js
+++ b/lib/utils/messenger.js
@@ -72,6 +72,17 @@ class Messenger {
       data.from = 'master';
     }
 
+    // recognise receiverPid is to who
+    if (data.receiverPid) {
+      if (data.receiverPid === String(process.pid)) {
+        data.to = 'master';
+      } else if (data.receiverPid === String(this.master.agentWorker.pid)) {
+        data.to = 'agent';
+      } else {
+        data.to = 'app';
+      }
+    }
+
     // default from -> to rules
     if (!data.to) {
       if (data.from === 'agent') data.to = 'app';

--- a/test/fixtures/apps/messenger/agent.js
+++ b/test/fixtures/apps/messenger/agent.js
@@ -1,5 +1,11 @@
 'use strict';
 
+const pids = {
+  master: process.ppid,
+  worker: new Set(),
+  agent: process.pid,
+};
+
 module.exports = function(agent) {
   // from parent
   agent.messenger.on('parent2agent', msg => console.log(msg));
@@ -21,4 +27,39 @@ module.exports = function(agent) {
 
   // compatible with string
   agent.messenger.on('app2agentbystring', msg => console.log('agent: ' + msg));
+
+  agent.messenger.on('egg-ready', () => {
+    agent.messenger.sendToApp('worker_online', { type: 'agent', pid: process.pid });
+  });
+
+  agent.messenger.on('worker_online', data => {
+    workerOnline(data);
+    sendToProcess(agent.messenger);
+  });
+
+  agent.messenger.on('send_to_pid', data => {
+    if (data.type === 'app') {
+      console.log('app sendTo agent done');
+    }
+    if (data.type === 'agent') {
+      console.log('agent sendTo agent done');
+    }
+  });
 };
+
+function workerOnline(data) {
+  if (data.type === 'agent') {
+    pids.agent = data.pid;
+  } else {
+    pids.worker.add(data.pid);
+  }
+}
+
+function sendToProcess(messenger) {
+  const data = { type: 'agent', fromProcess: process.pid };
+  messenger.sendTo(pids.master, 'send_to_pid', data);
+  messenger.sendTo(pids.agent, 'send_to_pid', data);
+  for (const pid of pids.worker) {
+    messenger.sendTo(pid, 'send_to_pid', data);
+  }
+}

--- a/test/master.test.js
+++ b/test/master.test.js
@@ -279,6 +279,18 @@ describe('test/master.test.js', () => {
       yield sleep(1000);
       app.expect('stdout', /\d+ 'got'/);
     });
+
+    it('sendTo should work', function* () {
+      app = utils.cluster('apps/messenger');
+      // app.debug();
+      yield app.end();
+      app.proc.on('message', console.log);
+      yield sleep(1000);
+      app.expect('stdout', /app sendTo agent done/);
+      app.expect('stdout', /agent sendTo agent done/);
+      app.expect('stdout', /app sendTo app done/);
+      app.expect('stdout', /agent sendTo app done/);
+    });
   });
 
   describe('--cluster', () => {


### PR DESCRIPTION
`sendTo` should can send to master, agent, worker as doc mentioned.

> app.messenger.sendTo(pid, action, data): send messages to specified process

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
messenger

##### Description of change
<!-- Provide a description of the change below this comment. -->
