### PR TITLE
feat: kill agent after workers are killed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - '6'
   - '8'
+  - '10'
 env:
   - EGG_VERSION=1
   - EGG_VERSION=2

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ startCluster(options, () => {
 | typescript   | `Boolean` | enable loader's typescript support       |
 | require      | `Array|String` | will inject into worker/agent process |
 
+## Env
+
+EGG_APP_CLOSE_TIMEOUT: app worker boot timeout value
+
+EGG_AGENT_CLOSE_TIMEOUT: agent worker boot timeout value
+
 ## License
 
 [MIT](LICENSE)

--- a/lib/master.js
+++ b/lib/master.js
@@ -531,7 +531,7 @@ class Master extends EventEmitter {
         process.exit(0);
       } catch (e) /* istanbul ignore next */ {
         this.logger.error('[master] close with error: ', e);
-        process.exit(0);
+        process.exit(1);
       }
     });
   }

--- a/lib/master.js
+++ b/lib/master.js
@@ -12,6 +12,9 @@ const detectPort = require('detect-port');
 const ConsoleLogger = require('egg-logger').EggConsoleLogger;
 const utility = require('utility');
 const semver = require('semver');
+const awaitEvent = require('await-event');
+const sleep = require('mz-modules/sleep');
+const co = require('co');
 
 const Manager = require('./utils/manager');
 const parseOptions = require('./utils/options');
@@ -284,21 +287,30 @@ class Master extends EventEmitter {
    *
    * https://www.exratione.com/2013/05/die-child-process-die/
    * make sure Agent Worker exit before master exit
+   *
+   * @param {number} timeout - kill agent timeout
+   * @return {Promise} -
    */
-  killAgentWorker() {
+  killAgentWorker(timeout) {
     if (this.agentWorker) {
       this.log('[master] kill agent worker with signal SIGTERM');
       this.agentWorker.removeAllListeners();
-      this.agentWorker.kill('SIGTERM');
     }
+    const self = this;
+    return co(function* () {
+      yield self._killSubProcess(self.agentWorker, timeout);
+    });
   }
 
-  killAppWorkers() {
-    for (const id in cluster.workers) {
-      const worker = cluster.workers[id];
-      worker.disableRefork = true;
-      worker.process.kill('SIGTERM');
-    }
+  killAppWorkers(timeout) {
+    const self = this;
+    return co(function* () {
+      yield Object.keys(cluster.workers).map(id => {
+        const worker = cluster.workers[id];
+        worker.disableRefork = true;
+        return self._killSubProcess(worker, timeout);
+      });
+    });
   }
 
   /**
@@ -511,21 +523,17 @@ class Master extends EventEmitter {
 
   close() {
     this.closed = true;
-    // kill app workers
-    // kill agent worker
-    // exit itself
-    this.killAppWorkers();
-    this.killAgentWorker();
-    // sleep to make sure SIGTERM send to the child processes
-    const timeout = process.env.EGG_MASTER_CLOSE_TIMEOUT || 5000;
-
-    this.log('[master] send kill SIGTERM to app workers and agent worker, will exit with code:0 after %sms', timeout);
-    this.logger.info('[master] wait %sms', timeout);
-    setTimeout(() => {
-      this.log('[master] close done, exiting with code:0');
-      // FIXME: master should wait agent/app exit
-      process.exit(0);
-    }, timeout);
+    const self = this;
+    co(function* () {
+      try {
+        yield self._doClose();
+        self.log('[master] close done, exiting with code:0');
+        process.exit(0);
+      } catch (e) /* istanbul ignore next */ {
+        this.logger.error('[master] close with error: ', e);
+        process.exit(0);
+      }
+    });
   }
 
   getAgentWorkerFile() {
@@ -534,6 +542,44 @@ class Master extends EventEmitter {
 
   getAppWorkerFile() {
     return path.join(__dirname, 'app_worker.js');
+  }
+
+  * _killSubProcess(subProcess, timeout) {
+    subProcess.kill('SIGTERM');
+    yield Promise.race([
+      awaitEvent(subProcess, 'exit'),
+      sleep(timeout),
+    ]);
+    if (subProcess.killed) {
+      return;
+    }
+    // SIGKILL: http://man7.org/linux/man-pages/man7/signal.7.html
+    // worker: https://github.com/nodejs/node/blob/master/lib/internal/cluster/worker.js#L22
+    // subProcess.kill is wrapped to subProcess.destroy, it will wait to disconnected.
+    (subProcess.process || subProcess).kill('SIGKILL');
+  }
+
+  * _doClose() {
+    // kill app workers
+    // kill agent worker
+    // exit itself
+    const legacyTimeout = process.env.EGG_MASTER_CLOSE_TIMEOUT || 5000;
+    const appTimeout = process.env.EGG_APP_CLOSE_TIMEOUT || legacyTimeout;
+    const agentTimeout = process.env.EGG_AGENT_CLOSE_TIMEOUT || legacyTimeout;
+    this.logger.info('[master] send kill SIGTERM to app workers, will exit with code:0 after %sms', appTimeout);
+    this.logger.info('[master] wait %sms', appTimeout);
+    try {
+      yield this.killAppWorkers(appTimeout);
+    } catch (e) /* istanbul ignore next */ {
+      this.logger.error('[master] app workers exit error: ', e);
+    }
+    this.logger.info('[master] send kill SIGTERM to agent worker, will exit with code:0 after %sms', agentTimeout);
+    this.logger.info('[master] wait %sms', agentTimeout);
+    try {
+      yield this.killAgentWorker(agentTimeout);
+    } catch (e) /* istanbul ignore next */ {
+      this.logger.error('[master] agent worker exit error: ', e);
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -32,8 +32,10 @@
   },
   "homepage": "https://github.com/eggjs/egg-cluster#readme",
   "dependencies": {
+    "await-event": "^2.1.0",
     "cfork": "^1.7.1",
     "cluster-reload": "^1.0.2",
+    "co": "^4.6.0",
     "debug": "^3.1.0",
     "depd": "^1.1.2",
     "detect-port": "^1.2.2",
@@ -42,6 +44,7 @@
     "get-ready": "^2.0.1",
     "graceful-process": "^1.2.0",
     "is-type-of": "^1.2.0",
+    "mz-modules": "^2.1.0",
     "semver": "^5.5.0",
     "sendmessage": "^1.1.0",
     "utility": "^1.13.1"
@@ -49,7 +52,6 @@
   "devDependencies": {
     "address": "^1.0.3",
     "autod": "^3.0.1",
-    "await-event": "^2.1.0",
     "coffee": "^4.1.0",
     "egg": "^2.8.1",
     "egg-bin": "^4.7.0",
@@ -58,7 +60,6 @@
     "eslint": "^4.19.1",
     "eslint-config-egg": "^7.0.0",
     "mz": "^2.7.0",
-    "mz-modules": "^2.1.0",
     "pedding": "^1.1.0",
     "supertest": "^3.1.0",
     "ts-node": "^6.0.3",

--- a/test/fixtures/apps/worker-close-timeout/agent.js
+++ b/test/fixtures/apps/worker-close-timeout/agent.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const sleep = require('mz-modules/sleep');
+
+module.exports = app => {
+  const timeout = process.env.EGG_MASTER_CLOSE_TIMEOUT || 5000;
+
+  app.beforeClose(function* () {
+    app.logger.info('agent worker start close: ' + Date.now());
+    yield sleep(timeout * 2);
+    app.logger.info('agent worker: never called after timeout');
+  });
+};

--- a/test/fixtures/apps/worker-close-timeout/app.js
+++ b/test/fixtures/apps/worker-close-timeout/app.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const sleep = require('mz-modules/sleep');
+
+module.exports = app => {
+  const timeout = process.env.EGG_MASTER_CLOSE_TIMEOUT || 5000;
+
+  app.beforeClose(function* () {
+    app.logger.info('app worker start close', Date.now(), timeout);
+    yield sleep(timeout * 2);
+    app.logger.info('app worker never called after timeout');
+  });
+};

--- a/test/fixtures/apps/worker-close-timeout/package.json
+++ b/test/fixtures/apps/worker-close-timeout/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "worker-close-timeout"
+}


### PR DESCRIPTION
kill order: workers -> agent -> master

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
由于 Egg 的进程模型，杀进程时，同时关闭 agent 和 app 可能会导致一些错误的发生，例如 cluster-client 中的 ECONNREFUSED。因此将进程关闭顺序调整为 app worker -> agent worker -> master。

