### PR TITLE
change the default debug port to support multiple debugger

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -188,7 +188,7 @@ class Master extends EventEmitter {
     const opt = {};
 
     // add debug execArgv
-    const debugPort = process.env.EGG_AGENT_DEBUG_PORT || 5800;
+    const debugPort = process.env.EGG_AGENT_DEBUG_PORT || parseInt(Math.random() * 1000) + 5800;
     if (this.options.isDebug) opt.execArgv = process.execArgv.concat([ `--${semver.gte(process.version, '8.0.0') ? 'inspect' : 'debug'}-port=${debugPort}` ]);
 
     const agentWorker = childprocess.fork(this.getAgentWorkerFile(), args, opt);


### PR DESCRIPTION
change the default debug port from 5800 to [5800, 6800]

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
