### PR TITLE
fix: should destroy socket when receives an RST after the three-way handshake

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -168,7 +168,10 @@ class Master extends EventEmitter {
 
       /* istanbul ignore next */
       if (!connection.remoteAddress) {
-        connection.close();
+        // This will happen when a client sends an RST(which is set to 1) right
+        // after the three-way handshake to the server.
+        // Read https://en.wikipedia.org/wiki/TCP_reset_attack for more details.
+        connection.destroy();
       } else {
         const worker = this.stickyWorker(connection.remoteAddress);
         worker.send('sticky-session:connection', connection);


### PR DESCRIPTION

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

The sticky style server won't suffer when RST comes after the three-way handshake.

##### Description of change
<!-- Provide a description of the change below this comment. -->

Basically, this case will happen when a client sends an RST(which is set to 1) right after the three-way handshake to the server. If the server receives the RST packet, connection.remoteAddress will be undefined.

The previous implementation is wrong due to the incorrect method is invoked.

It's hard to write this kind of test to send an RST after the three-way handshake(perhaps we can use C to do that).

Reference: 
- https://nodejs.org/dist/latest-v10.x/docs/api/net.html#net_socket_destroy_exception
- https://en.wikipedia.org/wiki/TCP_reset_attack