### PR TITLE
fix: should not ready when call server.listen in sticky mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const Master = require('./lib/master');
 
 /**
  * start egg app
- * @method Egg#startCluster
+ * @function Egg#startCluster
  * @param {Object} options {@link Master}
  * @param {Function} callback start success callback
  */

--- a/lib/app_worker.js
+++ b/lib/app_worker.js
@@ -66,7 +66,7 @@ function startServer(err) {
   app.emit('server', server);
 
   if (options.sticky) {
-    server.listen(0, '127.0.0.1');
+    server.listen(options.stickyWorkerPort, '127.0.0.1');
     // Listen to messages sent from the master. Ignore everything else.
     process.on('message', (message, connection) => {
       if (message !== 'sticky-session:connection') {

--- a/lib/master.js
+++ b/lib/master.js
@@ -9,7 +9,7 @@ const EventEmitter = require('events');
 const childprocess = require('child_process');
 const cfork = require('cfork');
 const ready = require('get-ready');
-const detectPort = require('detect-port');
+const GetFreePort = require('detect-port');
 const ConsoleLogger = require('egg-logger').EggConsoleLogger;
 const utility = require('utility');
 const semver = require('semver');
@@ -28,7 +28,7 @@ const REALPORT = Symbol('Master#realport');
 class Master extends EventEmitter {
 
   /**
-   * @constructor
+   * @class
    * @param {Object} options
    *  - {String} [framework] - specify framework that can be absolute path or npm package
    *  - {String} [baseDir] directory of application, default to `process.cwd()`
@@ -129,17 +129,10 @@ class Master extends EventEmitter {
       fs.writeFileSync(this.options.pidFile, process.pid, 'utf-8');
     }
 
-    detectPort((err, port) => {
-      /* istanbul ignore if */
-      if (err) {
-        err.name = 'ClusterPortConflictError';
-        err.message = '[master] try get free port error, ' + err.message;
-        this.logger.error(err);
-        process.exit(1);
-      }
-      this.options.clusterPort = port;
-      this.forkAgentWorker();
-    });
+    this.detectPorts()
+      .then(() => {
+        this.forkAgentWorker();
+      });
 
     // exit when agent or worker exception
     this.workerManager.on('exception', ({ agent, worker }) => {
@@ -150,6 +143,28 @@ class Master extends EventEmitter {
       process.exit(1);
     });
   }
+
+  detectPorts() {
+    // Detect cluster client port
+    return GetFreePort()
+      .then(port => {
+        this.options.clusterPort = port;
+        // If sticky mode, detect worker port
+        if (this.options.sticky) {
+          return GetFreePort();
+        }
+      })
+      .then(port => {
+        if (this.options.sticky) {
+          this.options.stickyWorkerPort = port;
+        }
+      })
+      .catch(/* istanbul ignore next */ err => {
+        this.logger.error(err);
+        process.exit(1);
+      });
+  }
+
 
   log(...args) {
     this.logger[this.logMethod](...args);
@@ -445,10 +460,13 @@ class Master extends EventEmitter {
     const worker = this.workerManager.getWorker(data.workerPid);
     const address = data.address;
 
-    // ignore unspecified port
-    // and it is ramdom port when use sticky
-    if (!this.options.sticky
-      && !isUnixSock(address)
+    // worker should listen stickyWorkerPort when sticky mode
+    if (this.options.sticky) {
+      if (String(address.port) !== String(this.options.stickyWorkerPort)) {
+        return;
+      }
+      // worker should listen REALPORT when not sticky mode
+    } else if (!isUnixSock(address)
       && (String(address.port) !== String(this[REALPORT]))) {
       return;
     }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "autod": "autod",
     "lint": "eslint .",
-    "test": "npm run lint && npm run test-local",
+    "test": "npm run lint -- --fix && npm run test-local",
     "test-local": "egg-bin test",
     "cov": "egg-bin cov --prerequire --timeout 100000",
     "ci": "npm run lint && egg-bin pkgfiles --check && npm run cov",

--- a/test/app_worker.test.js
+++ b/test/app_worker.test.js
@@ -223,7 +223,7 @@ describe('test/app_worker.test.js', () => {
           .expect(200);
         throw new Error('should not run');
       } catch (err) {
-        assert(err.code === 'ECONNREFUSED');
+        assert(/ECONNREFUSED/.test(err.message));
       }
     });
 

--- a/test/fixtures/apps/cluster_mod_sticky/app.js
+++ b/test/fixtures/apps/cluster_mod_sticky/app.js
@@ -1,6 +1,14 @@
 'use strict';
 
+const net = require('net');
+
 module.exports = app => {
   // don't use the port that egg-mock defined
   app._options.port = undefined;
+  const server = net.createServer();
+  server.listen(9500);
+
+  app.beforeClose(() => {
+    return server.close();
+  });
 };

--- a/test/master.test.js
+++ b/test/master.test.js
@@ -828,6 +828,7 @@ describe('test/master.test.js', () => {
     after(() => app.close());
 
     it('should online sticky cluster mode startup success', () => {
+      app.expect('stdout', /app_worker#\d:\d+ started at (?!9500)/);
       app.expect('stdout', /egg started on http:\/\/127.0.0.1:17010/);
       return request('http://127.0.0.1:17010')
         .get('/portal/i.htm')


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
修复在 sticky 模式下，其他的 server.listen 不会对应用启动造成影响。

##### Description of change
<!-- Provide a description of the change below this comment. -->
