### PR TITLE
feat: kill worker with SIGTERM first

### DIFF
--- a/lib/utils/terminate.js
+++ b/lib/utils/terminate.js
@@ -18,7 +18,16 @@ function* killProcess(subProcess, timeout) {
   subProcess.kill('SIGTERM');
   yield Promise.race([
     awaitEvent(subProcess, 'exit'),
-    sleep(timeout),
+    sleep(timeout / 2),
+  ]);
+  if (subProcess.killed) return;
+
+  if (subProcess.process) {
+    subProcess.process.kill('SIGTERM');
+  }
+  yield Promise.race([
+    awaitEvent(subProcess, 'exit'),
+    sleep(timeout / 2),
   ]);
   if (subProcess.killed) return;
   // SIGKILL: http://man7.org/linux/man-pages/man7/signal.7.html


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
current workflow for killing a worker:

`worker.kill('SIGTERM') -> wait -> worker.process.kill('SIGKILL')`

when `worker.kill()` timed out, `worker.process.kill('SIGKILL')` is invoked, causing the process to quit immediately, make packages like `signal-exit` unusable.

to fix this, `worker.process.kill('SIGTERM')` is added in between:

`worker.kill('SIGTERM') -> wait -> worker.process.kill('SIGTERM') -> wait -> worker.process.kill('SIGKILL')`
