### PR TITLE
fix: worker_threads mode without ports

### DIFF
--- a/lib/utils/mode/impl/worker_threads/app.js
+++ b/lib/utils/mode/impl/worker_threads/app.js
@@ -156,7 +156,10 @@ class AppUtils extends BaseAppUtils {
     this.startSuccessCount = 0;
 
     const ports = this.options.ports;
-    this.options.workers = ports.length ? ports.length : 1;
+    if (!ports.length) {
+      ports.push(this.options.port);
+    }
+    this.options.workers = ports.length;
     let i = 0;
     do {
       const options = Object.assign({}, this.options, { port: ports[i] });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

fix: worker_threads 模式下，指定 port 不指定 ports 时， port 不生效的问题

* 复现方式：

```bash
$ PORT=8080 egg-scripts start --title=egg-server-xxx --workers=1 --startMode worker_threads
```

* 实际结果：

监听7001端口

* 期望结果：

监听8080端口

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
