### PR TITLE
feat: log cluster module IPC via onelogger

### DIFF
--- a/lib/app_worker.js
+++ b/lib/app_worker.js
@@ -25,20 +25,55 @@ try {
   consoleLogger.error(err);
   throw err;
 }
+
+// IPC logging — register after `new Application` so that app constructors which throw synchronously
+// (e.g. fixtures that trigger framework errors) do not pay the extra require/listener cost nor
+// perturb the timing of events that were racing with master-side teardown before this change.
+const { ipcLogger, formatIpcMessage, internalIpcLogEnabled } = require('./utils/ipc_logger');
+
+// D. master -> app (recv): log every IPC message delivered to this worker via the cluster channel.
+// Handle is present when master forwards a net.Socket (sticky-session mode).
+// This listener is read-only; other `process.on('message')` listeners (framework, sticky handler,
+// etc.) are unaffected.
+process.on('message', (msg, handle) => {
+  const body = typeof msg === 'string' ? { action: msg } : msg;
+  ipcLogger.info(formatIpcMessage(`app#${process.pid}<-master`, body, handle));
+});
+
+// F. master -> app internal NODE_CLUSTER messages (newconn with fd, disconnect, suicide, ...).
+// `internalMessage` is an undocumented but stable Node.js event.
+// Opt-in via EGG_CLUSTER_IPC_LOG because `newconn` fires once per HTTP request.
+if (internalIpcLogEnabled) {
+  process.on('internalMessage', (msg, handle) => {
+    if (!msg || msg.cmd !== 'NODE_CLUSTER') return;
+    const label = msg.act ? `cluster:${msg.act}` : `cluster:ack#${msg.ack != null ? msg.ack : '?'}`;
+    ipcLogger.info(formatIpcMessage(
+      `app#${process.pid}<-master`,
+      { action: label, data: msg },
+      handle
+    ));
+  });
+}
+
 const clusterConfig = app.config.cluster || /* istanbul ignore next */ {};
 const listenConfig = clusterConfig.listen || /* istanbul ignore next */ {};
 const httpsOptions = Object.assign({}, clusterConfig.https, options.https);
 const port = options.port = options.port || listenConfig.port;
 const protocol = (httpsOptions.key && httpsOptions.cert) ? 'https' : 'http';
 
-process.send({
+// C. app -> master (send): there is exactly one direct process.send() in the app worker — `realport`.
+// All other master-side lifecycle info (app-start / app-exit) is derived from cluster events, not from
+// explicit app-to-master sends.
+const realportMessage = {
   to: 'master',
   action: 'realport',
   data: {
     port,
     protocol,
   },
-});
+};
+ipcLogger.info(formatIpcMessage(`app#${process.pid}->master`, realportMessage));
+process.send(realportMessage);
 
 app.ready(startServer);
 

--- a/lib/master.js
+++ b/lib/master.js
@@ -21,6 +21,7 @@ const Manager = require('./utils/manager');
 const parseOptions = require('./utils/options');
 const Messenger = require('./utils/messenger');
 const terminate = require('./utils/terminate');
+const { ipcLogger, formatIpcMessage, internalIpcLogEnabled } = require('./utils/ipc_logger');
 
 const PROTOCOL = Symbol('Master#protocol');
 const REAL_PORT = Symbol('Master#real_port');
@@ -217,6 +218,13 @@ class Master extends EventEmitter {
         connection.destroy();
       } else {
         const worker = this.stickyWorker(connection.remoteAddress);
+        // A'. master -> app sticky-session direct send (bypasses messenger.sendToAppWorker),
+        // carries a net.Socket handle — safe-printed by formatIpcMessage's replacer.
+        ipcLogger.info(formatIpcMessage(
+          `master->app#${worker.process.pid}`,
+          { action: 'sticky-session:connection' },
+          connection
+        ));
         worker.send('sticky-session:connection', connection);
       }
     }).listen(this[REAL_PORT], cb);
@@ -319,7 +327,11 @@ class Master extends EventEmitter {
     cluster.on('fork', worker => {
       worker.disableRefork = true;
       this.workerManager.setWorker(worker);
-      worker.on('message', msg => {
+      // B. master <- app (recv). Handle is present when master receives a net.Socket
+      // (e.g. forwarded sticky-session connection).
+      // Log AFTER forwarding to avoid adding log-serialization latency to the forward path
+      // (some tests rely on tight timing of app->master->agent round-trips).
+      worker.on('message', (msg, handle) => {
         if (typeof msg === 'string') {
           msg = {
             action: msg,
@@ -328,7 +340,25 @@ class Master extends EventEmitter {
         }
         msg.from = 'app';
         this.messenger.send(msg);
+        ipcLogger.info(formatIpcMessage(`master<-app#${worker.process.pid}`, msg, handle));
       });
+
+      // E. cluster internal NODE_CLUSTER messages from worker to master:
+      // listening / online / queryServer / accepted (fd ack) / close / ...
+      // Must hook on `worker.process` (ChildProcess) — `cluster.Worker` doesn't forward `internalMessage`.
+      // `internalMessage` is undocumented but stable across Node.js versions.
+      // Opt-in via EGG_CLUSTER_IPC_LOG because this is verbose under load.
+      if (internalIpcLogEnabled) {
+        worker.process.on('internalMessage', (msg, handle) => {
+          if (!msg || msg.cmd !== 'NODE_CLUSTER') return;
+          const label = msg.act ? `cluster:${msg.act}` : `cluster:ack#${msg.ack != null ? msg.ack : '?'}`;
+          ipcLogger.info(formatIpcMessage(
+            `master<-app#${worker.process.pid}`,
+            { action: label, data: msg },
+            handle
+          ));
+        });
+      }
       this.log('[master] app_worker#%s:%s start, state: %s, current workers: %j',
         worker.id, worker.process.pid, worker.state, Object.keys(cluster.workers));
 

--- a/lib/utils/ipc_logger.js
+++ b/lib/utils/ipc_logger.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const net = require('net');
+const { getLogger } = require('onelogger');
+
+/**
+ * onelogger instance for Node.js cluster module IPC traffic between master and app workers.
+ * Users can override the underlying sink via `onelogger.setLogger()` / `setCustomLogger()`.
+ */
+const ipcLogger = getLogger('egg-cluster:ipc');
+
+/**
+ * Whether internal-level cluster IPC logs (NODE_CLUSTER newconn/accepted/listening/...) are enabled.
+ * These are very verbose (one `cluster:newconn` per HTTP request), so they are opt-in
+ * via the `EGG_CLUSTER_IPC_LOG` environment variable (any truthy value enables).
+ */
+const internalIpcLogEnabled = !!process.env.EGG_CLUSTER_IPC_LOG;
+
+const MAX_STRING_LEN = 200;
+const MAX_TOTAL_LEN = 1024;
+
+function describeHandle(handle) {
+  if (handle == null) return '';
+  if (handle instanceof net.Socket) {
+    const fd = handle._handle && handle._handle.fd;
+    return fd != null ? `<Socket fd=${fd}>` : '<Socket>';
+  }
+  if (handle instanceof net.Server) {
+    return '<Server>';
+  }
+  const ctor = handle.constructor && handle.constructor.name;
+  return ctor ? `<${ctor}>` : '<handle>';
+}
+
+function makeReplacer() {
+  const seen = new WeakSet();
+  return function replacer(_key, value) {
+    if (value && typeof value === 'object') {
+      if (seen.has(value)) return '<Circular>';
+      seen.add(value);
+      if (value instanceof net.Socket) return describeHandle(value);
+      if (value instanceof net.Server) return '<Server>';
+      if (Buffer.isBuffer(value)) return `<Buffer len=${value.length}>`;
+    }
+    if (typeof value === 'string' && value.length > MAX_STRING_LEN) {
+      return `${value.slice(0, MAX_STRING_LEN)}...(truncated)`;
+    }
+    return value;
+  };
+}
+
+function stringifyData(data) {
+  let out;
+  try {
+    out = JSON.stringify(data, makeReplacer());
+  } catch (err) {
+    return `<unserializable: ${err.message}>`;
+  }
+  if (out && out.length > MAX_TOTAL_LEN) {
+    out = `${out.slice(0, MAX_TOTAL_LEN)}...(truncated)`;
+  }
+  return out;
+}
+
+/**
+ * Format a single IPC message into a one-line log string.
+ * @param {string} direction e.g. 'master->app#12345' / 'app#12345<-master'
+ * @param {Object} msg       the message body (supports cluster internal msgs via `action: 'cluster:<act>'`)
+ * @param {*} [handle]       optional handle (net.Socket / net.Server / TCP) attached to the IPC message
+ * @return {string}
+ */
+function formatIpcMessage(direction, msg, handle) {
+  const action = (msg && msg.action) || '<unknown>';
+  let out = `[${direction}] action=${action}`;
+  if (msg && msg.data !== undefined) {
+    out += ` data=${stringifyData(msg.data)}`;
+  }
+  if (handle) {
+    out += ` +handle=${describeHandle(handle)}`;
+  }
+  return out;
+}
+
+module.exports = {
+  ipcLogger,
+  internalIpcLogEnabled,
+  formatIpcMessage,
+};

--- a/lib/utils/messenger.js
+++ b/lib/utils/messenger.js
@@ -3,6 +3,7 @@
 const cluster = require('cluster');
 const sendmessage = require('sendmessage');
 const debug = require('debug')('egg-cluster:messenger');
+const { ipcLogger, formatIpcMessage } = require('./ipc_logger');
 
 
 /**
@@ -162,6 +163,8 @@ class Messenger {
       if (data.receiverPid && data.receiverPid !== String(worker.process.pid)) {
         continue;
       }
+      // A. master -> app (send)
+      ipcLogger.info(formatIpcMessage(`master->app#${worker.process.pid}`, data));
       sendmessage(worker, data);
     }
   }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "ps-tree": "^1.2.0",
     "semver": "^5.6.0",
     "sendmessage": "^1.1.0",
-    "utility": "^1.15.0"
+    "utility": "^1.15.0",
+    "onelogger": "^1.0.1"
   },
   "devDependencies": {
     "address": "^1.0.3",


### PR DESCRIPTION
## Summary

Add structured logging for every master↔app worker IPC point under Node.js `cluster` mode, using [onelogger](https://github.com/node-modules/onelogger) as the logger facade. Same feature as its v3 (master-branch) counterpart, ported to 1.x's plain JavaScript `lib/` layout.

Covers both layers of cluster IPC:

**Application layer** (always on)

| Point | Direction | Where |
|---|---|---|
| A  | master → app send         | `lib/utils/messenger.js` `sendToAppWorker` — all routed master→app sends (every worker in the loop) |
| A' | master → app send (w/ fd) | `lib/master.js` sticky-session `worker.send('sticky-session:connection', connection)` |
| B  | master ← app recv         | `lib/master.js` `cluster.on('fork')` → `worker.on('message', (msg, handle) => ...)`; the log fires **after** forwarding to avoid adding serialization latency to the forward path |
| C  | app → master send         | `lib/app_worker.js` — the single explicit `process.send({action:'realport'})` |
| D  | app ← master recv         | `lib/app_worker.js` new `process.on('message', (msg, handle) => ...)` |

**Cluster internal layer** (opt-in via `EGG_CLUSTER_IPC_LOG=1`; very verbose — `newconn` fires once per HTTP request)

| Point | Direction | Observes |
|---|---|---|
| E | master ← app internal | `online` / `listening` / `queryServer` / `accepted` **(fd ack)** / `close` — via `worker.process.on('internalMessage')` |
| F | app ← master internal | `newconn` **(fd dispatch, handle=`<TCP>`)** / `disconnect` / `suicide` — via `process.on('internalMessage')` |

Note: `internalMessage` is an undocumented Node.js event but has been stable across major versions. E/F hook on `worker.process` (ChildProcess) rather than `cluster.Worker`, since the latter does not forward `internalMessage`.

Agent worker (`child_process.fork`) is intentionally out of scope — not a `cluster` module component.

Users can replace the default console sink via `onelogger.setLogger()` / `setCustomLogger()`.

`formatIpcMessage` has a safe replacer: `net.Socket` / `net.Server` / Buffer / circular refs are collapsed to tokens; long strings are truncated at 200 chars; whole JSON payload is capped at 1024 chars. Handles get a `+handle=<Socket fd=N>` / `<TCP>` / `<Server>` suffix.

## Sample output

With \`EGG_CLUSTER_IPC_LOG=1\` and a real HTTP request against the \`egg-ready\` fixture:

\`\`\`
[egg-cluster:ipc] [master<-app#86211] action=cluster:online
[egg-cluster:ipc] [app#86211->master] action=realport data={\"port\":17011,\"protocol\":\"http\"}
[egg-cluster:ipc] [master<-app#86211] action=realport data={\"port\":17011,\"protocol\":\"http\"}
[egg-cluster:ipc] [master<-app#86211] action=cluster:queryServer
[egg-cluster:ipc] [app#86211<-master] action=cluster:ack#1 data={\"cmd\":\"NODE_CLUSTER\",\"ack\":1,...,\"sockname\":{...}}
[egg-cluster:ipc] [master<-app#86211] action=cluster:listening
[egg-cluster:ipc] [master->app#86211] action=egg-ready data={...}
[egg-cluster:ipc] [app#86211<-master] action=egg-ready data={...}
[egg-cluster:ipc] [master<-app#86211] action=cluster:ack#1 data={\"cmd\":\"NODE_CLUSTER\",\"ack\":1,\"accepted\":true}   ← fd ack
[egg-cluster:ipc] [app#86211<-master] action=cluster:newconn ... +handle=<TCP>                                     ← fd dispatch
\`\`\`

## Notes for 1.x

- \`onelogger\` declares \`engines: >=16.0.0\` but its CJS output only uses ES5 features; functionally works on older Node too (install may print an engines warning on Node < 16).
- Places where v3's \`AppProcessWorker\` wrapper class would have been instrumented are handled here at the \`messenger.sendToAppWorker\` level instead (1.x has no such wrapper).
- In \`lib/app_worker.js\`, the \`ipc_logger\` require and listener registrations live **after** \`new Application(options)\` construction. This matters for fixtures whose Application constructor throws synchronously (e.g. \`agent-die-on-forkapp\`) — the added code never runs in those cases and does not perturb the pre-existing race between \`onAppExit\` and \`onAgentExit\`.

## Test plan

- [x] Manual: startCluster on \`egg-ready\` fixture with \`EGG_CLUSTER_IPC_LOG=1\` + real HTTP request → all 7 points (A/A'/B/C/D/E/F) print as expected, including \`cluster:newconn +handle=<TCP>\` (fd dispatch) and \`cluster:ack#1 accepted:true\` (fd ack). No Socket serialization errors.
- [x] \`egg-bin test\` full suite — 90 passing / 6 failing. Pre-existing (reproduced against stashed baseline):
  - 4 \`FrameworkErrorformater\` tests: brackets regex mismatch (pre-existing egg-errors URL formatting difference)
  - 1 \`listen config path\` test: Unix socket ENOENT (pre-existing environment issue)
  - 1 \`should master exit when agent exit during app worker boot\`: pre-existing flaky (4/5 pass rate both with and without this change — racy fixture that depends on \`egg-core\` \`getResolvedFilename\` not throwing, which it does on newer Node)

🤖 Generated with [Claude Code](https://claude.com/claude-code)